### PR TITLE
Missing variable files

### DIFF
--- a/src/deployster.py
+++ b/src/deployster.py
@@ -20,7 +20,7 @@ from jinja2 import UndefinedError
 from jsonschema import ValidationError
 
 import util
-from util import ask, log, err, indent, unindent
+from util import ask, log, warn, err, indent, unindent
 
 
 class UserError(Exception):
@@ -720,10 +720,14 @@ def main():
             super().__init__(option_strings, dest, nargs, const, default, type, choices, required, help, metavar)
 
         def __call__(self, parser, namespace, values, option_string=None):
-            if not hasattr(namespace, self.dest) or not getattr(namespace, self.dest):
-                setattr(namespace, self.dest, Context())
-            context: Context = getattr(namespace, self.dest)
-            context.add_file(values)
+            if os.path.exists(values):
+                if not hasattr(namespace, self.dest) or not getattr(namespace, self.dest):
+                    setattr(namespace, self.dest, Context())
+                context: Context = getattr(namespace, self.dest)
+                context.add_file(values)
+            else:
+                warn(yellow(
+                    f"WARNING: context file '{values}' does not exist (manifest processing might result in errors)."))
 
     # parse arguments
     argparser = argparse.ArgumentParser(description="Deployment automation tool.",

--- a/src/util.py
+++ b/src/util.py
@@ -62,7 +62,13 @@ def logp(message) -> None:
     print(emoji.emojize(_msg(message), use_aliases=True), flush=True, end='')
 
 
+def warn(message) -> None:
+    # TODO: print warnings in yellow (but review calls to 'warn(msg)' to remove manual yellow coloring)
+    print(emoji.emojize(_msg(message), use_aliases=True), flush=True, file=sys.stderr)
+
+
 def err(message) -> None:
+    # TODO: print errors in red (but review calls to 'err(msg)' to remove manual red coloring)
     print(emoji.emojize(_msg(message), use_aliases=True), flush=True, file=sys.stderr)
 
 


### PR DESCRIPTION
Allow supplying non-existing files to "--var-file" arguments, and warn instead of failing on such cases.