### PR TITLE
Pull resource images proactively and TTY improvements

### DIFF
--- a/deployster.sh
+++ b/deployster.sh
@@ -8,8 +8,15 @@ fi
 # default deployster version to "latest" unless supplied as environment variable already
 [[ "${DEPLOYSTER_VERSION}" == "" ]] && DEPLOYSTER_VERSION="latest"
 
+# Docker args
+if [[ -t 1 ]]; then
+    INTERACTIVE_ARGS="-it"
+else
+    INTERACTIVE_ARGS=""
+fi
+
 # run!
-docker run -it \
+docker run ${INTERACTIVE_ARGS} \
            -v $(pwd):/deployster/workspace \
            -v $(pwd)/work:/deployster/work \
            -v /var/run/docker.sock:/var/run/docker.sock \

--- a/src/deployster.py
+++ b/src/deployster.py
@@ -14,6 +14,7 @@ from typing import Sequence, Mapping, MutableMapping, Callable, MutableSequence,
 
 import jinja2
 import jsonschema
+import termios
 import yaml
 from colors import bold, underline, red, italic, faint, yellow, green
 from jinja2 import UndefinedError
@@ -800,11 +801,19 @@ def main():
         else:
             err(red(e.message))
         exit(1)
+
+    except termios.error as e:
+        unindent(fully=True)
+        err('')
+        err(red(f"IO error: {e}"))
+        exit(1)
+
     except KeyboardInterrupt:
         unindent(fully=True)
         err('')
         err(red(f"Interrupted."))
         exit(1)
+
     except Exception:
         # always print stacktrace since this exception is an unexpected exception
         err(red(traceback.format_exc()))


### PR DESCRIPTION
Pull resource Docker images proactively during bootstrap phase.
Improve handling of TTY errors, and update `deployster.sh` to automatically detect when its running in a terminal (or not) and invoke the `docker run` command appropiately (send `-it` or not).