### PR TITLE
Fix potential bug when accessing a "DResource" properties.

### DIFF
--- a/resources/src/dresources.py
+++ b/resources/src/dresources.py
@@ -253,7 +253,7 @@ class DResource(ABC):
 
         This is in essence the actual state of the resource, but is only available if previously calculated by this
         resource, and subsequently provided by Deployster."""
-        return self._info.config
+        return self._info.properties
 
     def get_plug(self, name: str) -> DPlug:
         return self._plugs[name]


### PR DESCRIPTION
Thankfully the bug did not yet manifest to anywhere except places accessing an "GcpIpAddress" actual IP address (which takes it from its own properties), because currently "GcpIpAddress" is the only place using this feature right now.