### PR TITLE
Fix RBAC role action.

### DIFF
--- a/resources/src/k8s_rbac_role.py
+++ b/resources/src/k8s_rbac_role.py
@@ -117,7 +117,7 @@ class K8sRbacRole(K8sResource):
         return actions
 
     @action
-    def update_role_rules(self, args):
+    def update_rules(self, args):
         if args: pass
 
         patch = json.dumps([{"op": "replace", "path": "/rules", "value": self.rules}])


### PR DESCRIPTION
The "update-rules" action could not be invoked due to the wrong name being used on the action descriptor.