### PR TITLE
Add missing dependencies to Kubernetes resource images.

### DIFF
--- a/resources/Dockerfile.k8s
+++ b/resources/Dockerfile.k8s
@@ -1,3 +1,3 @@
 FROM infolinks/deployster-dresource:local
 RUN gcloud components install kubectl
-COPY src/k8s.py src/gcp_gke_cluster.py /deployster/lib/
+COPY src/gcp.py src/gcp_services.py src/gcp_project.py src/k8s.py src/gcp_gke_cluster.py /deployster/lib/


### PR DESCRIPTION
Kubernetes resources are currently still GKE-bound, which means they still need GCP dependencies:
- `gcp.py`
- `gcp_services.py`
- `gcp_project.py`