### PR TITLE
Expose deployster context variable

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -79,7 +79,7 @@ cd deployster/examples
 Now lets run one of the manifests:
 
 ```bash
-../deployster.sh --var deployster_version=latest ./cluster.yaml
+../deployster.sh ./cluster.yaml
 ```
 
 ## Notes

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -6,7 +6,7 @@ plugs:
 resources:
 
   test-cluster:
-    type: infolinks/deployster-gcp-gke-cluster:{{ deployster_version }}
+    type: infolinks/deployster-gcp-gke-cluster:{{ _version }}
     dependencies:
       project: test-project
     config:
@@ -21,7 +21,7 @@ resources:
           preemptible: true
 
   cluster-admin-role:
-    type: infolinks/deployster-k8s-rbac-role:{{ deployster_version }}
+    type: infolinks/deployster-k8s-rbac-role:{{ _version }}
     readonly: true
     dependencies:
       cluster: test-cluster
@@ -37,12 +37,12 @@ resources:
             verbs: ['*']
 
   test-administrator-user:
-    type: infolinks/deployster-k8s-rbac-user:{{ deployster_version }}
+    type: infolinks/deployster-k8s-rbac-user:{{ _version }}
     config:
       name: {{ test_admin_user }}
 
   test-administrator-binding:
-    type: infolinks/deployster-k8s-rbac-role-binding:{{ deployster_version }}
+    type: infolinks/deployster-k8s-rbac-role-binding:{{ _version }}
     dependencies:
       role: cluster-admin-role
       user: test-administrator-user

--- a/examples/project.yaml
+++ b/examples/project.yaml
@@ -8,7 +8,7 @@ plugs:
 resources:
 
   test-project:
-    type: infolinks/deployster-gcp-project:{{ deployster_version }}
+    type: infolinks/deployster-gcp-project:{{ _version }}
     config:
       project_id: {{ gcp_project }}
       organization_id: {{ organization_id }}

--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -6,4 +6,4 @@ echo "Building..." >&2
 $(dirname $0)/../.buildkite/build.sh ${VERSION} 2>&1 1>> ./.build.log
 [[ $? != 0 ]] && echo "Build failed! (inspect '.build.log' for details)" >&2 && exit 1
 
-DEPLOYSTER_VERSION=${VERSION} source $(dirname $0)/../deployster.sh --no-pull --var deployster_version=0.0.0 $@
+source $(dirname $0)/../deployster.sh --no-pull $@

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -1,7 +1,7 @@
 resources:
 
   test-sql:
-    type: infolinks/deployster-gcp-cloud-sql:{{ deployster_version }}
+    type: infolinks/deployster-gcp-cloud-sql:{{ _version }}
     dependencies:
       project: test-project
     config:

--- a/src/deployster.py
+++ b/src/deployster.py
@@ -833,6 +833,7 @@ def main():
     log('')
 
     context: Context = Context()
+    context.add_variable("_version", version)
     for file in os.listdir(os.path.expanduser('~/.deployster')):
         if re.match(r'^vars\.(.*\.)?auto\.yaml$', file):
             context.add_file(os.path.expanduser('~/.deployster/' + file))


### PR DESCRIPTION
This allows setting resource image versions to `{{ _version }}` to always align them to the currently-running Deployster version.