### PR TITLE
Fix Kubernetes bugs

### DIFF
--- a/resources/Dockerfile.dresource
+++ b/resources/Dockerfile.dresource
@@ -12,6 +12,3 @@ RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf && 
 # setup Python execution
 ENV PYTHONPATH "/deployster/lib:$PYTHONPATH"
 ENV PYTHONUNBUFFERED="1"
-
-# copy sources
-COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/

--- a/resources/Dockerfile.dresource
+++ b/resources/Dockerfile.dresource
@@ -2,8 +2,9 @@ FROM centos:7.4.1708
 
 # install dependencies
 COPY google-cloud-sdk.repo /etc/yum.repos.d/
-RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm && \
-    yum install -y python36u python36u-pip && \
+RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf && \
+    yum install -y https://centos7.iuscommunity.org/ius-release.rpm && \
+    yum install -y which python36u python36u-pip && \
     yum install -y google-cloud-sdk kubectl && \
     yum clean all && \
     pip3.6 install PyYAML PyMySQL google-api-python-client ansicolors

--- a/resources/Dockerfile.gcp
+++ b/resources/Dockerfile.gcp
@@ -1,3 +1,4 @@
 FROM infolinks/deployster-dresource:local
 ENV GOOGLE_APPLICATION_CREDENTIALS=/deployster/service-account.json
+COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/gcp.py /deployster/lib/

--- a/resources/Dockerfile.gcp_cloud_sql
+++ b/resources/Dockerfile.gcp_cloud_sql
@@ -2,6 +2,7 @@ FROM infolinks/deployster-gcp:local
 RUN curl -sSL -o "/usr/local/bin/cloud_sql_proxy" "https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64" && \
     chmod +x /usr/local/bin/cloud_sql_proxy && \
     yum install -y mariadb && yum clean all
+COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/gcp_cloud_sql.py /deployster/lib/
 RUN chmod +x /deployster/lib/gcp_cloud_sql.py
 ENTRYPOINT ["/deployster/lib/gcp_cloud_sql.py"]

--- a/resources/Dockerfile.gcp_compute_ip_address
+++ b/resources/Dockerfile.gcp_compute_ip_address
@@ -1,4 +1,5 @@
 FROM infolinks/deployster-gcp:local
+COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/gcp_compute_ip_address.py /deployster/lib/
 RUN chmod +x /deployster/lib/gcp_compute_ip_address.py
 ENTRYPOINT ["/deployster/lib/gcp_compute_ip_address.py"]

--- a/resources/Dockerfile.gcp_gke_cluster
+++ b/resources/Dockerfile.gcp_gke_cluster
@@ -1,4 +1,5 @@
 FROM infolinks/deployster-gcp:local
+COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/gcp_gke_cluster.py /deployster/lib/
 RUN chmod +x /deployster/lib/gcp_gke_cluster.py
 ENTRYPOINT ["/deployster/lib/gcp_gke_cluster.py"]

--- a/resources/Dockerfile.gcp_project
+++ b/resources/Dockerfile.gcp_project
@@ -1,4 +1,5 @@
 FROM infolinks/deployster-gcp:local
+COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/gcp_project.py /deployster/lib/
 RUN chmod +x /deployster/lib/gcp_project.py
 ENTRYPOINT ["/deployster/lib/gcp_project.py"]

--- a/resources/Dockerfile.k8s
+++ b/resources/Dockerfile.k8s
@@ -1,5 +1,6 @@
 FROM infolinks/deployster-dresource:local
 RUN yum install -y kubectl && yum clean all
+COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/k8s*.py /deployster/lib/
 RUN chmod +x /deployster/lib/k8s_main.py
 ENTRYPOINT ["/deployster/lib/k8s_main.py"]

--- a/resources/src/dresources.py
+++ b/resources/src/dresources.py
@@ -152,6 +152,10 @@ class DResourceInfo:
         return Path(self._data['workspace'])
 
     @property
+    def has_config(self)->bool:
+        return 'config' in self._data
+
+    @property
     def config(self) -> Mapping[str, Any]:
         """The resource configuration, which in essence is the *desired* state of the resource, as depicted by the user
         in the deployment manifest."""

--- a/resources/src/external_services.py
+++ b/resources/src/external_services.py
@@ -226,6 +226,8 @@ class ExternalServices:
             if status == 409:
                 raise Exception(f"failed creating SQL instance, possibly due to instance name reuse (you can't "
                                 f"reuse an instance name for a week after its deletion)") from e
+            else:
+                raise
 
     def patch_gcp_sql_instance(self, project_id: str, instance: str, body: dict) -> None:
         service = self._get_gcp_service('sqladmin', 'v1beta4')

--- a/resources/src/external_services.py
+++ b/resources/src/external_services.py
@@ -508,15 +508,19 @@ class ExternalServices:
         process = subprocess.run(f"{cmd}", shell=True, check=True, stdout=subprocess.PIPE)
         return json.loads(process.stdout) if process.stdout else None
 
-    def create_k8s_object(self, manifest: dict, timeout: int = 60 * 5) -> None:
-        subprocess.run(f"kubectl create -f -",
+    def create_k8s_object(self, manifest: dict, timeout: int = 60 * 5, verbose: bool = False) -> None:
+        if verbose:
+            print(f"Creating Kubernetes object from:\n{json.dumps(manifest, indent=2)}")
+        subprocess.run(f"kubectl create --save-config=true -f -",
                        input=json.dumps(manifest),
                        encoding='utf-8',
                        check=True,
                        timeout=timeout,
                        shell=True)
 
-    def update_k8s_object(self, manifest: dict, timeout: int = 60 * 5) -> None:
+    def update_k8s_object(self, manifest: dict, timeout: int = 60 * 5, verbose: bool = False) -> None:
+        if verbose:
+            print(f"Updating Kubernetes object from:\n{json.dumps(manifest, indent=2)}")
         subprocess.run(f"kubectl apply -f -",
                        input=json.dumps(manifest),
                        encoding='utf-8',

--- a/resources/src/external_services.py
+++ b/resources/src/external_services.py
@@ -4,7 +4,7 @@ import sys
 from abc import abstractmethod
 from pathlib import Path
 from time import sleep
-from typing import Sequence, MutableMapping, Union, Any, Mapping
+from typing import Sequence, MutableMapping, Union, Any, Mapping, MutableSequence
 
 import pymysql
 from googleapiclient.discovery import build
@@ -215,6 +215,15 @@ class ExternalServices:
                 if instance['name'] == instance_name:
                     return instance
         return None
+
+    def get_gcp_sql_users(self, project_id: str, instance_name: str) -> Sequence[dict]:
+        users_service = self._get_gcp_service('sqladmin', 'v1beta4').users()
+        result = users_service.list(project=project_id, instance=instance_name).execute()
+        users: MutableSequence[dict] = []
+        if 'items' in result:
+            for user in result['items']:
+                users.append({'name': user['name'], 'password': user['password'] if 'password' in user else None})
+        return users
 
     def create_gcp_sql_instance(self, project_id: str, body: dict) -> None:
         sql_service = self._get_gcp_service('sqladmin', 'v1beta4')

--- a/resources/src/gcp_cloud_sql.py
+++ b/resources/src/gcp_cloud_sql.py
@@ -525,10 +525,12 @@ class GcpCloudSql(GcpResource):
             }
         })
 
-        cfg: dict = self.info.config
-        if "maintenance" in cfg and cfg["maintenance"] is not None:
-            if 'day' in cfg["maintenance"] and type(cfg["maintenance"]['day']) == str:
-                cfg["maintenance"]['day'] = _translate_day_name_to_number(cfg["maintenance"]['day'])
+        # translate maintenance window name to number
+        if self.info.has_config:
+            cfg: dict = self.info.config
+            if "maintenance" in cfg and cfg["maintenance"] is not None:
+                if 'day' in cfg["maintenance"] and type(cfg["maintenance"]['day']) == str:
+                    cfg["maintenance"]['day'] = _translate_day_name_to_number(cfg["maintenance"]['day'])
 
     def discover_state(self):
         cfg: dict = self.info.config
@@ -861,9 +863,13 @@ class GcpCloudSql(GcpResource):
 
         # create instance
         project_id: str = cfg['project_id']
+        if self.info.verbose:
+            print(f"Creating Cloud SQL instance using:\n{json.dumps(body, indent=2)}")
         self.svc.create_gcp_sql_instance(project_id=project_id, body=body)
 
         # set 'root' password
+        if self.info.verbose:
+            print(f"Updating root user's password")
         self.svc.update_gcp_sql_user(project_id=project_id, instance=cfg['name'], password=cfg['root-password'])
 
         # check for scripts that need to be executed

--- a/resources/src/gcp_cloud_sql.py
+++ b/resources/src/gcp_cloud_sql.py
@@ -508,7 +508,7 @@ class GcpCloudSql(GcpResource):
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "name": {"type": "string", "minLength": 4},
+                            "name": {"type": "string", "minLength": 1},
                             "password": {"type": "string", "minLength": 5}
                         }
                     }

--- a/resources/src/gcp_project.py
+++ b/resources/src/gcp_project.py
@@ -82,8 +82,6 @@ class GcpProject(GcpResource):
                         description=f"Set billing account to '{desired_billing_account}'"))
 
         if 'apis' in config:
-            # TODO: fail if the same API is both enabled & disabled
-
             apis = config['apis']
             if 'disabled' in apis:
                 for api_name in apis['disabled']:

--- a/resources/src/gcp_project.py
+++ b/resources/src/gcp_project.py
@@ -51,9 +51,9 @@ class GcpProject(GcpResource):
         project: dict = self.svc.find_gcp_project(self.info.config['project_id'])
         if project is None:
             return None
-        elif project['lifecycleState'] == 'DELETE_REQUESTED':
+        elif 'lifecycleState' in project and project['lifecycleState'] == 'DELETE_REQUESTED':
             raise Exception(f"project '{self.info.config['project_id']}' is pending deletion, and is thus unusable")
-        elif project['lifecycleState'] != 'ACTIVE':
+        elif 'lifecycleState' in project and project['lifecycleState'] != 'ACTIVE':
             raise Exception(f"project '{self.info.config['project_id']}' is {project['lifecycleState']} "
                             f"(must be ACTIVE)")
 

--- a/resources/src/gcp_project.py
+++ b/resources/src/gcp_project.py
@@ -51,6 +51,11 @@ class GcpProject(GcpResource):
         project: dict = self.svc.find_gcp_project(self.info.config['project_id'])
         if project is None:
             return None
+        elif project['lifecycleState'] == 'DELETE_REQUESTED':
+            raise Exception(f"project '{self.info.config['project_id']}' is pending deletion, and is thus unusable")
+        elif project['lifecycleState'] != 'ACTIVE':
+            raise Exception(f"project '{self.info.config['project_id']}' is {project['lifecycleState']} "
+                            f"(must be ACTIVE)")
 
         actual_billing: dict = self.svc.find_gcp_project_billing_info(self.info.config['project_id'])
         if actual_billing is not None and 'billingAccountName' in actual_billing:

--- a/resources/src/k8s.py
+++ b/resources/src/k8s.py
@@ -91,6 +91,7 @@ class K8sResource(DResource):
     def build_kubectl_manifest(self) -> dict:
         return deepcopy(self.info.config['manifest'])
 
+    @action
     def state(self, args) -> None:
         if self.timeout_interval_ms >= self.timeout_ms:
             raise Exception(f"timeout interval ({self.timeout_interval_ms / 1000}) cannot be greater "

--- a/resources/src/k8s.py
+++ b/resources/src/k8s.py
@@ -1,8 +1,9 @@
+import sys
+import time
 from copy import deepcopy
+from pprint import pprint
 from time import sleep
 from typing import Sequence, MutableSequence
-
-import time
 
 from dresources import DAction, action, DResource
 from dresources_util import collect_differences
@@ -31,7 +32,7 @@ class K8sResource(DResource):
                 },
                 "manifest": {
                     "type": "object",
-                    "required": ["apiVersion", "kind", "metadata"],
+                    "required": ["metadata"],
                     "additionalProperties": True,
                     "properties": {
                         "apiVersion": {"type": "string", "minLength": 1},
@@ -80,8 +81,15 @@ class K8sResource(DResource):
     def get_actions_for_discovered_state(self, state: dict) -> Sequence[DAction]:
         actions: MutableSequence[DAction] = []
 
-        differences: Sequence[str] = collect_differences(desired=self.info.config['manifest'], actual=state)
+        differences: list = collect_differences(desired=self.info.config['manifest'], actual=state)
+        if 'apiVersion' in differences:
+            differences.remove('apiVersion')
+        if 'kind' in differences:
+            differences.remove('kind')
         if differences:
+            if self.info.verbose:
+                print("Found state differences: ", file=sys.stderr)
+                pprint(differences, stream=sys.stderr)
             kind: str = self.info.config['manifest']['kind']
             name: str = self.info.config['manifest']['metadata']['name']
             actions.append(DAction(name='update', description=f"Update {kind.lower()} '{name}'", args=['update']))
@@ -102,7 +110,7 @@ class K8sResource(DResource):
     def create(self, args) -> None:
         if args: pass
         start_ms: int = int(round(time.time() * 1000))
-        self.svc.create_k8s_object(self.build_kubectl_manifest(), self.timeout_ms)
+        self.svc.create_k8s_object(self.build_kubectl_manifest(), self.timeout_ms, self.info.verbose)
         finish_ms: int = int(round(time.time() * 1000))
         creation_duration_ms: int = finish_ms - start_ms
         remaining_timeout_ms: int = self.timeout_ms - creation_duration_ms
@@ -115,7 +123,7 @@ class K8sResource(DResource):
     def update(self, args) -> None:
         if args: pass
         start_ms: int = int(round(time.time() * 1000))
-        self.svc.update_k8s_object(self.build_kubectl_manifest(), self.timeout_ms)
+        self.svc.update_k8s_object(self.build_kubectl_manifest(), self.timeout_ms, self.info.verbose)
         finish_ms: int = int(round(time.time() * 1000))
         creation_duration_ms: int = finish_ms - start_ms
         remaining_timeout_ms: int = self.timeout_ms - creation_duration_ms

--- a/resources/src/k8s.py
+++ b/resources/src/k8s.py
@@ -58,10 +58,6 @@ class K8sResource(DResource):
             }
         })
 
-        if self.timeout_interval_ms >= self.timeout_ms:
-            raise Exception(f"timeout interval ({self.timeout_interval_ms / 1000}) cannot be greater "
-                            f"than or equal to total timeout ({self.timeout_ms / 1000}) duration")
-
     @property
     def timeout_ms(self) -> int:
         return self.info.config['timeout_ms'] if 'timeout_ms' in self.info.config else 60 * 5 * 1000
@@ -94,6 +90,12 @@ class K8sResource(DResource):
 
     def build_kubectl_manifest(self) -> dict:
         return deepcopy(self.info.config['manifest'])
+
+    def state(self, args) -> None:
+        if self.timeout_interval_ms >= self.timeout_ms:
+            raise Exception(f"timeout interval ({self.timeout_interval_ms / 1000}) cannot be greater "
+                            f"than or equal to total timeout ({self.timeout_ms / 1000}) duration")
+        super().state(args)
 
     @action
     def create(self, args) -> None:

--- a/resources/src/k8s_ingress.py
+++ b/resources/src/k8s_ingress.py
@@ -8,7 +8,6 @@ class K8sIngress(K8sResource):
         super().__init__(data=data, svc=svc)
 
     def is_available(self, state: dict) -> bool:
-        # TODO: consider waiting for kube-lego to generate the TLS certificate from LetsEncrypt (if it's installed)
         if 'status' not in state:
             return False
 

--- a/resources/src/k8s_main.py
+++ b/resources/src/k8s_main.py
@@ -2,9 +2,8 @@
 
 import json
 import sys
-from typing import Callable, Mapping
+from typing import Mapping
 
-from external_services import ExternalServices
 from k8s import K8sResource
 from k8s_deployment import K8sDeployment
 from k8s_ingress import K8sIngress
@@ -13,27 +12,150 @@ from k8s_service import K8sService
 
 
 def main():
-    # mapping between resource types (docker images) to the K8sResource subclass to handle it
-    k8s_resource_types: Mapping[str, Callable[[dict, ExternalServices], K8sResource]] = {
-        "infolinks/deployster-k8s-deployment": K8sDeployment,
-        "infolinks/deployster-k8s-ingress": K8sIngress,
-        "infolinks/deployster-k8s-secret": K8sSecret,
-        "infolinks/deployster-k8s-service": K8sService
+    # mapping between resource types (docker images) and their associated Kubernetes kind & API versions, and the
+    # DResource subclass to handle them
+    k8s_object_types: Mapping[str, dict] = {
+        'infolinks/deployster-k8s-clusterrole': {
+            'kind': 'ClusterRole',
+            'api_version': 'rbac.authorization.k8s.io/v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-clusterrolebinding': {
+            'kind': 'ClusterRoleBinding',
+            'api_version': 'rbac.authorization.k8s.io/v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-configmap': {
+            'kind': 'ConfigMap',
+            'api_version': 'v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-cronjob': {
+            'kind': 'CronJob',
+            'api_version': 'batch/v1beta1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-daemonset': {
+            'kind': 'DaemonSet',
+            'api_version': 'apps/v1beta2',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-deployment': {
+            'kind': 'Deployment',
+            'api_version': 'apps/v1beta2',
+            'factory': K8sDeployment
+        },
+        'infolinks/deployster-k8s-horizontalpodautoscaler': {
+            'kind': 'HorizontalPodAutoscaler',
+            'api_version': 'autoscaling/v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-ingress': {
+            'kind': 'Ingress',
+            'api_version': 'extensions/v1beta1',
+            'factory': K8sIngress
+        },
+        'infolinks/deployster-k8s-job': {
+            'kind': 'Job',
+            'api_version': 'batch/v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-namespace': {
+            'kind': 'Namespace',
+            'api_version': 'v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-networkpolicy': {
+            'kind': 'NetworkPolicy',
+            'api_version': 'networking/v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-node': {
+            'kind': 'Node',
+            'api_version': 'v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-persistentvolume': {
+            'kind': 'PersistentVolume',
+            'api_version': 'v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-persistentvolumeclaim': {
+            'kind': 'PersistentVolumeClaim',
+            'api_version': 'v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-pod': {
+            'kind': 'Pod',
+            'api_version': 'v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-replicaset': {
+            'kind': 'ReplicaSet',
+            'api_version': 'apps/v1beta2',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-replicationcontroller': {
+            'kind': 'ReplicationController',
+            'api_version': 'v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-role': {
+            'kind': 'Role',
+            'api_version': 'rbac.authorization.k8s.io/v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-rolebinding': {
+            'kind': 'RoleBinding',
+            'api_version': 'rbac.authorization.k8s.io/v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-secret': {
+            'kind': 'Secret',
+            'api_version': 'v1',
+            'factory': K8sSecret
+        },
+        'infolinks/deployster-k8s-service': {
+            'kind': 'Service',
+            'api_version': 'v1',
+            'factory': K8sService
+        },
+        'infolinks/deployster-k8s-serviceaccount': {
+            'kind': 'ServiceAccount',
+            'api_version': 'v1',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-statefulset': {
+            'kind': 'StatefulSet',
+            'api_version': 'apps/v1beta2',
+            'factory': K8sResource
+        },
+        'infolinks/deployster-k8s-storageclass': {
+            'kind': 'StorageClass',
+            'api_version': 'storage/v1',
+            'factory': K8sResource
+        },
     }
 
     # read the current resource type from stdin, along with all the other information Deployster sends
     data = json.loads(sys.stdin.read())
-    resource_type: str = data['type']
+    resource_type: str = data['type'][0:data['type'].find(':')] if ':' in data['type'] else data['type']
 
     # search for the K8sResource subclass to pass execution to
-    resource_factory: Callable[[dict], K8sResource] = K8sResource
-    for type, resource_ctor in k8s_resource_types.items():
-        if resource_type.startswith(type):
-            resource_factory = resource_ctor
-            break
+    for type, info in k8s_object_types.items():
+        if resource_type == type:
+            if 'config' in data and 'manifest' in data['config']:
+                manifest: dict = data['config']['manifest']
+                if 'kind' not in manifest:
+                    manifest['kind'] = info['kind']
+                if 'apiVersion' not in manifest:
+                    manifest['apiVersion'] = info['api_version']
 
-    # no resource handler found; use the default K8sResource class
-    resource_factory(data=data).execute()
+            info['factory'](data=data).execute()
+            return
+
+    # no resource handler found!
+    raise Exception(f"resource type '{data['type']}' is not supported (this should not happen)")
 
 
 if __name__ == "__main__":

--- a/resources/src/k8s_main.py
+++ b/resources/src/k8s_main.py
@@ -26,13 +26,14 @@ def main():
     resource_type: str = data['type']
 
     # search for the K8sResource subclass to pass execution to
+    resource_factory: Callable[[dict], K8sResource] = K8sResource
     for type, resource_ctor in k8s_resource_types.items():
         if resource_type.startswith(type):
-            resource_ctor(data=data).execute()
-            return
+            resource_factory = resource_ctor
+            break
 
     # no resource handler found; use the default K8sResource class
-    K8sResource(data=data).execute()
+    resource_factory(data=data).execute()
 
 
 if __name__ == "__main__":

--- a/src/deployster.py
+++ b/src/deployster.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import termios
 import traceback
+from pathlib import Path
 
 from colors import bold, underline, green
 
@@ -89,7 +90,7 @@ def main():
         context.display()
 
         # load & display the manifest
-        manifest: Manifest = Manifest(context=context, manifest_files=args.manifests)
+        manifest: Manifest = Manifest(context=context, manifest_files=[Path(p).absolute() for p in args.manifests])
         manifest.display_plugs()
 
         # build the deployment plan, display, and potentially execute it

--- a/src/docker.py
+++ b/src/docker.py
@@ -26,7 +26,6 @@ class DockerInvoker:
                 input: dict = None,
                 stderr_logger: Logger = None,
                 stdout_logger: Logger = None) -> Tuple[int, str, str]:
-        # TODO: if image tag is "latest", re-pull; perhaps apply a global "pull policy" here?
 
         # the timestamp serves as a unique invocation ID in the work dir
         timestamp = datetime.datetime.utcnow().isoformat("T") + "Z"

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -138,6 +138,7 @@ class Resource:
                     spacious=False) as logger:
 
             # execute resource Docker image with the default entrypoint
+            # TODO: consider caching init results since they are not expected to change per resource-type
             result = self._docker_invoker.run_json(
                 logger=logger,
                 local_work_dir=self._manifest.context.work_dir / self.name / "init",

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -290,7 +290,13 @@ class Resource:
             try:
                 jsonschema.validate(self._resolved_config, self._config_schema)
             except ValidationError as e:
-                raise UserError(f"illegal config for '{self.name}.config.{'.'.join(e.path)}': {e.message}\n"
+                path: str = ''
+                for token in e.path:
+                    if path:
+                        path: str = path + '[' + str(token) + ']' if type(token) == int else path + '.' + str(token)
+                    else:
+                        path = str(token)
+                raise UserError(f"illegal config for '{self.name}.config.{path}': {e.message}\n"
                                 f"Must match schema: {e.schema}") from e
 
             # invoke the "state" action

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -492,6 +492,8 @@ class Manifest:
         return self._context
 
     def display_plugs(self) -> None:
+        # TODO: print manifest files too?
+
         with Logger(header=f":electric_plug: {underline('Plugs:')}"):
             for name, value in self.plugs.items():
                 with Logger(header=f":point_right: {name}: {bold(value.path)}", spacious=False):

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -138,7 +138,6 @@ class Resource:
                     spacious=False) as logger:
 
             # execute resource Docker image with the default entrypoint
-            # TODO: consider caching init results since they are not expected to change per resource-type
             result = self._docker_invoker.run_json(
                 logger=logger,
                 local_work_dir=self._manifest.context.work_dir / self.name / "init",
@@ -262,7 +261,6 @@ class Resource:
 
         # if we're already resolving, we have a circular dependency loop
         if self._status == ResourceStatus.RESOLVING:
-            # TODO: print dependency chain
             raise UserError(f"illegal config: circular resource dependency encountered!")
 
         # if we were already resolved, do nothing (this can happen)
@@ -348,7 +346,6 @@ class Resource:
                                 'staleState': state_result["staleState"] if "staleState" in state_result else {}
                             }
                         )
-                        # TODO: consider refreshing state after every action?
 
                 # verify that the resource is now VALID
                 updated_state_result: dict = self._resolve_state(logger=logger)
@@ -498,8 +495,6 @@ class Manifest:
         return self._context
 
     def display_plugs(self) -> None:
-        # TODO: print manifest files too?
-
         with Logger(header=f":electric_plug: {underline('Plugs:')}"):
             for name, value in self.plugs.items():
                 with Logger(header=f":point_right: {name}: {bold(value.path)}", spacious=False):

--- a/src/util.py
+++ b/src/util.py
@@ -2,11 +2,12 @@ import pprint
 import termios
 import tty
 from contextlib import AbstractContextManager
+from pathlib import Path
 from typing import Any, Callable
 
 import emoji
 from colors import *
-from jinja2 import Environment, Template, Undefined
+from jinja2 import Environment, Template, Undefined, FileSystemLoader
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 
 
@@ -117,7 +118,7 @@ def ask(logger: Logger, message: str, chars: str, default: str) -> str:
 
 def post_process(value: Any, context: dict) -> Any:
     def _evaluate(expr: str) -> Any:
-        environment: Environment = Environment()
+        environment: Environment = Environment(loader=FileSystemLoader(str(Path('.').absolute())))
         try:
             if expr.startswith('{{') and expr.endswith('}}') and expr.find('{{') == expr.rfind('{{'):
                 # line is a single expression (only one '{{' token at the beginning, and '}}' at the end)

--- a/src/util.py
+++ b/src/util.py
@@ -128,7 +128,7 @@ def post_process(value: Any, context: dict) -> Any:
                                     f"Context is: {pprint.pformat(context)}")
                 else:
                     return result
-            elif expr.find('{{') >= 0:
+            elif expr.find('{{') >= 0 or expr.find('{%') >= 0:
                 # given string contains a jinja expression, use normal templating
                 template: Template = environment.from_string(expr, globals=context)
                 return template.render(context)

--- a/src/util.py
+++ b/src/util.py
@@ -1,3 +1,4 @@
+import pprint
 import termios
 import tty
 from contextlib import AbstractContextManager
@@ -123,7 +124,8 @@ def post_process(value: Any, context: dict) -> Any:
                 expr = expr[2:len(expr) - 2]
                 result = environment.compile_expression(source=expr, undefined_to_none=False)(context)
                 if type(result) == Undefined:
-                    raise UserError(f"expression '{expr}' yielded an undefined result (are all variables defined?)")
+                    raise UserError(f"expression '{expr}' yielded an undefined result (are all variables defined?)\n"
+                                    f"Context is: {pprint.pformat(context)}")
                 else:
                     return result
             elif expr.find('{{') >= 0:
@@ -133,9 +135,11 @@ def post_process(value: Any, context: dict) -> Any:
             else:
                 return expr
         except UndefinedError as e:
-            raise UserError(f"undefined variable used in expression '{expr}': {e.message}") from e
+            raise UserError(f"undefined variable used in expression '{expr}': {e.message}\n"
+                            f"Context is: {pprint.pformat(context)}") from e
         except TemplateSyntaxError as e:
-            raise UserError(f"expression error in '{expr}': {e.message}") from e
+            raise UserError(f"expression error in '{expr}': {e.message}\n"
+                            f"Context is: {pprint.pformat(context)}") from e
 
     def _post_process_config(value) -> Any:
         if isinstance(value, str):

--- a/tests/mock_external_services.py
+++ b/tests/mock_external_services.py
@@ -119,6 +119,10 @@ class MockExternalServices(ExternalServices):
     def get_gcp_sql_instance(self, project_id: str, instance_name: str):
         return self._gcp_sql_instances[instance_name] if instance_name in self._gcp_sql_instances else None
 
+    def get_gcp_sql_users(self, project_id: str, instance_name: str) -> Sequence[dict]:
+        # TODO: support mocking Cloud SQL users
+        return []
+
     def create_gcp_sql_instance(self, project_id: str, body: dict) -> None:
         pass
 

--- a/tests/mock_external_services.py
+++ b/tests/mock_external_services.py
@@ -233,7 +233,7 @@ class MockExternalServices(ExternalServices):
         key = f"{api_version}-{kind}-{namespace}-{name}"
         return self._k8s_objects[key] if key in self._k8s_objects else None
 
-    def create_k8s_object(self, manifest: dict, timeout: int = 60 * 5) -> None:
+    def create_k8s_object(self, manifest: dict, timeout: int = 60 * 5, verbose: bool = True) -> None:
         api_version: str = manifest["apiVersion"]
         kind: str = manifest["kind"]
         metadata: dict = manifest["metadata"]
@@ -245,7 +245,7 @@ class MockExternalServices(ExternalServices):
             duration: int = self._k8s_create_times[key]
             time.sleep(duration / 1000)
 
-    def update_k8s_object(self, manifest: dict, timeout: int = 60 * 5) -> None:
+    def update_k8s_object(self, manifest: dict, timeout: int = 60 * 5, verbose: bool = True) -> None:
         api_version: str = manifest["apiVersion"]
         kind: str = manifest["kind"]
         metadata: dict = manifest["metadata"]

--- a/tests/scenarios/gcp_cloud_sql/condition_composites.yaml
+++ b/tests/scenarios/gcp_cloud_sql/condition_composites.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -43,6 +44,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings:
           locationPreference: {zone: europe-west1-a}
           tier: db-1
@@ -75,6 +77,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: ANY-nested-conditions-none-fulfilled
     mock:
@@ -95,6 +98,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: ANY-nested-conditions-one-fulfilled
     mock:
@@ -115,6 +119,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: execute-script, description: 'Execute ''my-script'' SQL scripts', args: [execute_scripts, my-script]}

--- a/tests/scenarios/gcp_cloud_sql/condition_schemas.yaml
+++ b/tests/scenarios/gcp_cloud_sql/condition_schemas.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -37,6 +38,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: execute-script, description: 'Execute ''my-script'' SQL scripts', args: [execute_scripts, my-script]}
@@ -56,6 +58,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: any_missing_with_existing_schemas
     mock:
@@ -73,6 +76,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: execute-script, description: 'Execute ''my-script'' SQL scripts', args: [execute_scripts, my-script]}

--- a/tests/scenarios/gcp_cloud_sql/condition_sql.yaml
+++ b/tests/scenarios/gcp_cloud_sql/condition_sql.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -43,6 +44,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: execute-script, description: 'Execute ''my-script'' SQL scripts', args: [execute_scripts, my-script]}
@@ -67,4 +69,5 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}

--- a/tests/scenarios/gcp_cloud_sql/condition_tables.yaml
+++ b/tests/scenarios/gcp_cloud_sql/condition_tables.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -39,6 +40,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: any_missing_with_missing_table
     mock:
@@ -55,6 +57,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: execute-script, description: 'Execute ''my-script'' SQL scripts', args: [execute_scripts, my-script]}
@@ -75,6 +78,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: execute-script, description: 'Execute ''my-script'' SQL scripts', args: [execute_scripts, my-script]}
@@ -93,4 +97,5 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}

--- a/tests/scenarios/gcp_cloud_sql/scripts.yaml
+++ b/tests/scenarios/gcp_cloud_sql/scripts.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -31,6 +32,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: execute-script, description: 'Execute ''my-script'' SQL scripts', args: [execute_scripts, my-script]}

--- a/tests/scenarios/gcp_cloud_sql/update_backup.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_backup.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -33,6 +34,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, backupConfiguration: {enabled: true, binaryLogEnabled: true, startTime: '02:00'}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-backup, description: 'Update SQL instance backup schedule to ''03:00''', args: [update_backup]}
@@ -47,6 +49,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, backupConfiguration: {enabled: true, binaryLogEnabled: true, startTime: '02:00'}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-backup, description: 'Disable SQL instance backups/binary-logging', args: [update_backup]}
@@ -68,6 +71,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, backupConfiguration: {enabled: true, binaryLogEnabled: true, startTime: '02:00'}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: enable_when_disabled
     mock:
@@ -80,6 +84,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, backupConfiguration: {enabled: false, binaryLogEnabled: false, startTime: '02:00'}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-backup, description: 'Enable SQL instance backup/binary-logging', args: [update_backup]}
@@ -94,6 +99,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, backupConfiguration: {enabled: true, binaryLogEnabled: false, startTime: '02:00'}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-backup, description: 'Enable SQL instance backup/binary-logging', args: [update_backup]}
@@ -108,6 +114,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, backupConfiguration: {enabled: true, binaryLogEnabled: true, startTime: '02:00'}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: disable_when_actual_state_has_no_backup_property
     resource:
@@ -118,6 +125,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: enable_with_schedule_when_already_enabled
     mock:
@@ -130,6 +138,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, backupConfiguration: {enabled: false, binaryLogEnabled: false}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: enable_when_disabled_implicitly
     resource:
@@ -141,6 +150,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-backup, description: 'Enable SQL instance backups', args: [update_backup]}

--- a/tests/scenarios/gcp_cloud_sql/update_flags.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_flags.yaml
@@ -18,6 +18,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -57,6 +58,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, databaseFlags: [{name: bool-flag, value: 'off'}], ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-flags, description: 'Update SQL instance flags', args: [update_flags]}
@@ -71,6 +73,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, databaseFlags: [{name: bool-flag, value: 'off'}], ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: int_flag_value_not_numeric
     resource:
@@ -111,6 +114,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, databaseFlags: [{name: int-flag, value: '10'}], ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-flags, description: 'Update SQL instance flags', args: [update_flags]}
@@ -125,6 +129,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, databaseFlags: [{name: int-flag, value: '10'}], ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: none_flag_must_not_have_value
     resource:
@@ -142,6 +147,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-flags, description: 'Update SQL instance flags', args: [update_flags]}
@@ -156,6 +162,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, databaseFlags: [{name: none-flag}], storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: str_flag_requires_value
     resource:
@@ -189,6 +196,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, databaseFlags: [{name: str-enum-flag, value: v2}], ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: str_enum_flag_updates_value
     mock:
@@ -201,6 +209,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, databaseFlags: [{name: str-enum-flag, value: v2}], ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-flags, description: 'Update SQL instance flags', args: [update_flags]}
@@ -222,6 +231,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, databaseFlags: [{name: str-flag, value: v2}], ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-flags, description: 'Update SQL instance flags', args: [update_flags]}
@@ -236,6 +246,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, databaseFlags: [{name: str-flag, value: v2}], ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: unsupported_flag_rejected
     resource:

--- a/tests/scenarios/gcp_cloud_sql/update_labels.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_labels.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -31,6 +32,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150, userLabels: {}}
   - description: update_labels_same_count_diff_labels
     mock:
@@ -43,6 +45,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150, userLabels: {k1: v1, k2: v2}}
       actions:
         - {name: update-labels, description: 'Update SQL instance user-labels', args: [update_labels]}
@@ -57,6 +60,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150, userLabels: {k1: v1, k2: v2}}
       actions:
         - {name: update-labels, description: 'Update SQL instance user-labels', args: [update_labels]}
@@ -71,6 +75,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150, userLabels: {k1: v1, k2: v2}}
       actions:
         - {name: update-labels, description: 'Update SQL instance user-labels', args: [update_labels]}
@@ -85,4 +90,5 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150, userLabels: {k1: v1, k2: v2}}

--- a/tests/scenarios/gcp_cloud_sql/update_maintenance.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_maintenance.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -31,6 +32,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 1, hour: 1}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-maintenance-window, description: 'Disable SQL instance maintenance window', args: [update_maintenance_window]}
@@ -43,6 +45,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 1, hour: 1}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: use_day_number_same_value_still_valid
     resource:
@@ -53,6 +56,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 1, hour: 1}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: use_day_name_diff_value
     resource:
@@ -63,6 +67,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 1, hour: 1}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-maintenance-window, description: 'Update SQL instance maintenance window', args: [update_maintenance_window]}
@@ -75,6 +80,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 1, hour: 1}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-maintenance-window, description: 'Update SQL instance maintenance window', args: [update_maintenance_window]}
@@ -87,4 +93,5 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 1, hour: 1}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}

--- a/tests/scenarios/gcp_cloud_sql/update_networks.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_networks.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -48,6 +49,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: [{name: net1, value: 1.2.3.4}, {name: net2, value: 2.3.4.5}]}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-authorized-networks, description: 'Update SQL instance authorized networks', args: [update_authorized_networks]}
@@ -67,6 +69,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: [{name: net1, value: 1.2.3.4}, {name: net2, value: 2.3.4.5}]}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-authorized-networks, description: 'Update SQL instance authorized networks', args: [update_authorized_networks]}
@@ -86,6 +89,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: [{name: net1, value: 1.2.3.4}, {name: net2, value: 2.3.4.5}]}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-authorized-networks, description: 'Update SQL instance authorized networks (found stale network: net2)', args: [update_authorized_networks]}
@@ -103,6 +107,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
   - description: enable_ssl_requirement
     mock:
@@ -118,6 +123,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: false, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-require-ssl, description: 'Update SQL instance to require SSL connections', args: [update_require_ssl]}
@@ -130,6 +136,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-require-ssl, description: 'Update SQL instance to not require SSL connections', args: [update_require_ssl]}
@@ -142,6 +149,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings:
           locationPreference: {zone: europe-west1-a}
           tier: db-1

--- a/tests/scenarios/gcp_cloud_sql/update_region.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_region.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -38,6 +39,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-zone, description: 'Update SQL instance preferred zone to ''europe-west1-b''', args: [update_zone]}

--- a/tests/scenarios/gcp_cloud_sql/update_storage.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_storage.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -32,6 +33,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings:
           locationPreference: {zone: europe-west1-a}
           tier: db-1
@@ -57,6 +59,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-data-disk-size, description: 'Update SQL instance data disk size from 15gb to 20gb', args: [update_data_disk_size]}
@@ -69,6 +72,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-data-disk-type, description: 'Update SQL instance data disk type to ''PD_HDD''', args: [update_data_disk_type]}
@@ -95,6 +99,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-storage-auto-resize, description: 'Update SQL instance storage auto-resizing', args: [update_storage_auto_resize]}
@@ -109,6 +114,7 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings:
           locationPreference: {zone: europe-west1-a}
           tier: db-1

--- a/tests/scenarios/gcp_cloud_sql/update_tier.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_tier.yaml
@@ -13,6 +13,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1
@@ -46,6 +47,7 @@ scenarios:
       staleState:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}
       actions:
         - {name: update-machine-type, description: 'Update SQL instance machine type to ''db-2''', args: [update_machine_type]}
@@ -58,4 +60,5 @@ scenarios:
       state:
         state: RUNNABLE
         region: europe-west1
+        users: []
         settings: {locationPreference: {zone: europe-west1-a}, tier: db-1, maintenanceWindow: {day: 2, hour: 18}, dataDiskSizeGb: '15', dataDiskType: PD_SSD, ipConfiguration: {requireSsl: true, authorizedNetworks: []}, storageAutoResize: true, storageAutoResizeLimit: 150}

--- a/tests/scenarios/gcp_cloud_sql/update_when_apis_disabled.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_when_apis_disabled.yaml
@@ -10,6 +10,7 @@ mock:
     sql1:
       state: RUNNABLE
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1

--- a/tests/scenarios/gcp_cloud_sql/update_when_not_runnable.yaml
+++ b/tests/scenarios/gcp_cloud_sql/update_when_not_runnable.yaml
@@ -12,6 +12,7 @@ mock:
     sql1:
       state: MIGRATING
       region: europe-west1
+      users: []
       settings:
         locationPreference: {zone: europe-west1-a}
         tier: db-1

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -14,19 +14,20 @@ from mock_external_services import MockDockerInvoker
 from util import UserError
 
 
-@pytest.mark.parametrize("work_dir", [None, "/unknown/file", "./tests/.cache/action1"])
+@pytest.mark.parametrize("work_dir", ["/unknown/file", "./tests/.cache/action1"])
 @pytest.mark.parametrize("name", [None, "", "action"])
 @pytest.mark.parametrize("description", [None, "", "desssscriippttion"])
 @pytest.mark.parametrize("image", [None, "", "immmaage"])
 @pytest.mark.parametrize("entrypoint", [None, "", "ennntrrrypopiint"])
 @pytest.mark.parametrize("args", [None, [], ["1"], ["1", "2"], ["1", "", ""]])
 def test_action(work_dir: str, name: str, description: str, image: str, entrypoint: str, args: Sequence[str]):
-    action: Action = Action(work_dir=Path(work_dir) if work_dir is not None else None,
+    action: Action = Action(work_dir=Path(work_dir),
                             name=name,
                             description=description,
                             image=image,
-                            entrypoint=entrypoint, args=args)
-    assert action.work_dir == (Path(work_dir) if work_dir is not None else None)
+                            entrypoint=entrypoint,
+                            args=args)
+    assert action.work_dir == Path(work_dir).absolute()
     assert action.name == name
     assert action.description == description
     assert action.image == image
@@ -66,7 +67,7 @@ def test_plug(name: str,
                       allowed_resource_names=allowed_resource_names,
                       allowed_resource_types=allowed_resource_types)
     assert plug.name == name
-    assert plug.path == Path(path)
+    assert plug.path == Path(path).absolute()
     assert plug.readonly == readonly
     assert plug.resource_name_patterns == allowed_resource_names
     assert plug.resource_type_patterns == allowed_resource_types
@@ -143,7 +144,7 @@ def test_manifest(capsys, description: str, dir: Path, scenario: dict, manifest_
                 for plug_name, expected_plug in expected['plugs'].items():
                     plug: Plug = manifest.plug(plug_name)
                     if 'name' in expected_plug: assert plug.name == expected_plug['name']
-                    if 'path' in expected_plug: assert plug.path == Path(expected_plug['path'])
+                    if 'path' in expected_plug: assert plug.path == Path(expected_plug['path']).absolute()
                     if 'readonly' in expected_plug: assert plug.readonly == expected_plug['readonly']
                     if 'resource_name_patterns' in expected_plug:
                         assert plug.resource_name_patterns == expected_plug['resource_name_patterns']
@@ -308,6 +309,6 @@ def test_resource_initialize(capsys):
     assert resource._state_action.args == init_result['state_action']['args']
     assert resource._status == ResourceStatus.INITIALIZED
     assert resource._plug_volumes == [
-        f"{str(scenario_dir / 'p2')}:{init_result['plugs']['readonly_plug']['container_path']}:ro",
-        f"{str(scenario_dir / 'p1')}:{init_result['plugs']['writable_plug']['container_path']}:rw"
+        f"{str((scenario_dir / 'p2').absolute())}:{init_result['plugs']['readonly_plug']['container_path']}:ro",
+        f"{str((scenario_dir / 'p1').absolute())}:{init_result['plugs']['writable_plug']['container_path']}:rw"
     ]

--- a/tests/test_resource_k8s.py
+++ b/tests/test_resource_k8s.py
@@ -49,7 +49,7 @@ def test_k8s_resource_check_availability(capsys, timeout_ms, timeout_interval_ms
                                             r"or equal to total timeout \(\d+(.\d+)?\) duration"):
             MockK8sResource(time_until_available_ms=time_until_available_ms,
                             data=data,
-                            svc=MockExternalServices(k8s_objects={}))
+                            svc=MockExternalServices(k8s_objects={})).execute(["state"])
     else:
         resource = MockK8sResource(time_until_available_ms=time_until_available_ms,
                                    data=data,


### PR DESCRIPTION
### New features:
- Support for creating GCP Cloud SQL users
- Detect GCP projects that are pending deletion (or simply not active) and fail when such projects are encountered
- Automatically infer Kubernetes resources' `kind` and `apiVersion` if missing in manifest
- Exclude `kind` & `apiVersion` changes in Kubernetes as causing a Kubernetes resource update
- Support Jinja `{% ... %}` expressions in manifest configuration values

### Bug fixes & minor changes:
- When user provides `--confirm=RESOURCE`, only ask for a confirmation for resources that have actual actions
- Reject Kubernetes timeout interval larger than the actual timeout
- Support extra verbosity in Kubernetes updates
- Use absolute paths across the board internally, which fixes issues when user or manifest provides relative paths
- Fix Cloud SQL maintenance window disablement (was not disabled when set to `null` in manifest)
- Improve validation error messages

### Internal improvements:
- Disable YUM fast-mirrors plugin in Docker images
- Improve Docker images build time significantly when core sources are modified