### PR TITLE
Fix missing Cloud SQL Jinja dependency

### DIFF
--- a/resources/Dockerfile.dresource
+++ b/resources/Dockerfile.dresource
@@ -6,7 +6,7 @@ RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf && 
     yum install -y https://centos7.iuscommunity.org/ius-release.rpm && \
     yum install -y which python36u python36u-pip && \
     yum install -y google-cloud-sdk kubectl && \
-    yum clean all && \
+    yum clean all && rm -rf /var/cache/yum && \
     pip3.6 install PyYAML PyMySQL google-api-python-client ansicolors
 
 # setup Python execution

--- a/resources/Dockerfile.gcp_cloud_sql
+++ b/resources/Dockerfile.gcp_cloud_sql
@@ -1,7 +1,7 @@
 FROM infolinks/deployster-gcp:local
 RUN curl -sSL -o "/usr/local/bin/cloud_sql_proxy" "https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64" && \
     chmod +x /usr/local/bin/cloud_sql_proxy && \
-    yum install -y mariadb && yum clean all && \
+    yum install -y mariadb && yum clean all && rm -rf /var/cache/yum && \
     pip3.6 --quiet --disable-pip-version-check --no-cache-dir install Jinja2
 COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/gcp_cloud_sql.py /deployster/lib/

--- a/resources/Dockerfile.gcp_cloud_sql
+++ b/resources/Dockerfile.gcp_cloud_sql
@@ -1,7 +1,8 @@
 FROM infolinks/deployster-gcp:local
 RUN curl -sSL -o "/usr/local/bin/cloud_sql_proxy" "https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64" && \
     chmod +x /usr/local/bin/cloud_sql_proxy && \
-    yum install -y mariadb && yum clean all
+    yum install -y mariadb && yum clean all && \
+    pip3.6 --quiet --disable-pip-version-check --no-cache-dir install Jinja2
 COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/gcp_cloud_sql.py /deployster/lib/
 RUN chmod +x /deployster/lib/gcp_cloud_sql.py

--- a/resources/Dockerfile.k8s
+++ b/resources/Dockerfile.k8s
@@ -1,5 +1,5 @@
 FROM infolinks/deployster-dresource:local
-RUN yum install -y kubectl && yum clean all
+RUN yum install -y kubectl && yum clean all && rm -rf /var/cache/yum
 COPY src/dresources_util.py src/dresources.py src/external_services.py /deployster/lib/
 COPY src/k8s*.py /deployster/lib/
 RUN chmod +x /deployster/lib/k8s_main.py

--- a/resources/src/gcp_cloud_sql.py
+++ b/resources/src/gcp_cloud_sql.py
@@ -329,7 +329,7 @@ class ScriptFile:
 
     def execute(self, sql_executor: SqlExecutor) -> None:
         if self._post_process:
-            escaped_file: Path = self._path.parent / ('.' + self._path.name + '.escaped')
+            escaped_file: Path = Path('/tmp') / self._path.name
             template: Template = Environment().from_string(open(self._path, 'r').read(), globals=self._context)
             with escaped_file.open(mode='w') as f:
                 f.write(template.render(self._context))


### PR DESCRIPTION
Install Jinja2 dependency in Cloud SQL resource image. Jinja is required for SQL scripts post-processing (when enabled).